### PR TITLE
Feature/47 ipad margins

### DIFF
--- a/src/styles/components/_logo.scss
+++ b/src/styles/components/_logo.scss
@@ -23,19 +23,19 @@
         width: initial;
     }
 
-    &__box {
+    &__picture {
         height: 100%;
         width: 100%;
         display: flex;
         align-items: center;
 
         @include media('<=tablet') {
-            padding: 1.0875rem 2.9rem;
+            padding: 1.0875rem var(--spacing-double-half);
             max-width: 20.875rem;
         }
 
-        @include media('<phone') {
-            padding: 1.0875rem 15%;
+        @include media('<=iphoneplus') {
+            padding: 1.0875rem var(--spacing-double);
         }
     }
 

--- a/src/styles/core/_grid.scss
+++ b/src/styles/core/_grid.scss
@@ -11,6 +11,11 @@
         max-width: unset;
 
         @include media('<desktop') {
+            padding-left: var(--spacing-double-half);
+            padding-right: var(--spacing-double-half);
+        }
+
+        @include media('<=iphoneplus') {
             padding-left: var(--spacing-double);
             padding-right: var(--spacing-double);
         }

--- a/src/styles/core/_variables.scss
+++ b/src/styles/core/_variables.scss
@@ -76,6 +76,15 @@
     // heights
     --height-73: calc(73vh - 10px);
     --mobile-height: 5.625rem;
+
+    @include media('<=tablet') {
+        --mobile-height: 5.75rem;
+    }
+    
+    @include media('<=iphoneplus') {
+        --mobile-height: calc(4.875rem);
+    }
+
     --mobile-social-width: var(--mobile-height);
 
     // Offsets

--- a/src/styles/core/_variables.scss
+++ b/src/styles/core/_variables.scss
@@ -12,9 +12,10 @@
     --color-white: #ffffff;
 
     // Spaces
+    --spacing-half: 0.5rem;
     --spacing: 1rem;
     --spacing-double: 2rem;
-    --spacing-half: 0.5rem;
+    --spacing-double-half: 2.5rem;
     --spacing-global: 6.875rem;
 
     // Fonts

--- a/src/templates/components/logo.hbs
+++ b/src/templates/components/logo.hbs
@@ -1,6 +1,6 @@
 <div class="logo-wrap {{#if bgColor}} {{bgColor}} {{/if}} {{position}}">
     <a class="logo" href="#header" title="Ir para a página inicial">
-        <picture class="logo__box">
+        <picture class="logo__picture">
             <source srcset="images/logo-mobile1x.png" media="(max-width: 375px)" loading="lazy" width="334" height="85">
             <source srcset="images/logo-mobile2x.png" media="(max-width: 768px)">
             <img class="logo__img" src={{logoPath}} loading="lazy" width="210" height="150"


### PR DESCRIPTION
This #47 will improve margins for tablets and phones.

<img width="768" alt="PixelSnap 2021-03-12 at 23 20 28@2x" src="https://user-images.githubusercontent.com/18724070/111018968-3b62fa80-838a-11eb-9a8c-8209e1e496d3.png">


<img width="341" alt="PixelSnap 2021-03-12 at 23 21 41@2x" src="https://user-images.githubusercontent.com/18724070/111018971-3ef68180-838a-11eb-9477-98bd2438cfdb.png">


Navbar's margins for Tablet and phone will be fixed on past PR #46

