### PR TITLE
Remove card (evens) margin-right for cards to avoid breaking layout

### DIFF
--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -8,12 +8,17 @@
     margin-bottom: var(--spacing-double);
     margin-right: var(--spacing-double);
 
+    &:nth-child(even) {
+        @include media('<fullhd') {
+            margin-right: 0;
+        }
+    }
+
     @include media('<=tablet') {
         margin-right: var(--spacing-half);
     }
 
     @include media('<=iphoneplus') {
-        margin-right: 0;
         width: 100%;
     }
 


### PR DESCRIPTION
This PR fixes bug #57.
It will remove evens cards' margin-right for screens larger than fullhd.
It will fix socios layout till it gets its next breakpoint to make height: auto